### PR TITLE
BE-3358 change deprecated POST payout?sync_mode=true to async

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
  * POST /v1/payments/orders/**ID**/do-void
  * POST /v1/identity/openidconnect/tokenservice
  * GET /v1/identity/openidconnect/userinfo/?schema=**SCHEMA**
- * POST /v1/payments/payouts?sync_mode=true
+ * POST /v1/payments/payouts
  * GET /v1/payment-experience/web-profiles
  * POST /v1/payment-experience/web-profiles
  * GET /v1/payment-experience/web-profiles/**ID**

--- a/client.go
+++ b/client.go
@@ -78,7 +78,6 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 		if err == nil && len(data) > 0 {
 			json.Unmarshal(data, errResp)
 		}
-
 		return errResp
 	}
 

--- a/client.go
+++ b/client.go
@@ -71,16 +71,6 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		errResp := &ErrorResponse{Response: resp}
-		data, err = ioutil.ReadAll(resp.Body)
-
-		if err == nil && len(data) > 0 {
-			json.Unmarshal(data, errResp)
-		}
-		return errResp
-	}
-
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {
 			io.Copy(w, resp.Body)
@@ -88,6 +78,16 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 			err = json.NewDecoder(resp.Body).Decode(v)
 			if err != nil {
 				return err
+			}
+
+			if resp.StatusCode < 200 || resp.StatusCode > 299 {
+				errResp := &ErrorResponse{Response: resp}
+				data, err = ioutil.ReadAll(resp.Body)
+
+				if err == nil && len(data) > 0 {
+					json.Unmarshal(data, errResp)
+				}
+				return errResp
 			}
 		}
 	}

--- a/payout.go
+++ b/payout.go
@@ -2,7 +2,7 @@ package paypalsdk
 
 import "fmt"
 
-// CreateSinglePayout submits a payout with an asynchronous API call, which immediately returns the results of a PayPal payment.
+// CreateSinglePayout submits a payout with an asynchronous API call.
 // For email payout set RecipientType: "EMAIL" and receiver email into Receiver
 // Endpoint: POST /v1/payments/payouts
 func (c *Client) CreateSinglePayout(p Payout) (*PayoutResponse, error) {

--- a/payout.go
+++ b/payout.go
@@ -2,17 +2,16 @@ package paypalsdk
 
 import "fmt"
 
-// CreateSinglePayout submits a payout with a synchronous API call, which immediately returns the results of a PayPal payment.
+// CreateSinglePayout submits a payout with an asynchronous API call, which immediately returns the results of a PayPal payment.
 // For email payout set RecipientType: "EMAIL" and receiver email into Receiver
-// Endpoint: POST /v1/payments/payouts?sync_mode=true
+// Endpoint: POST /v1/payments/payouts
 func (c *Client) CreateSinglePayout(p Payout) (*PayoutResponse, error) {
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.APIBase, "/v1/payments/payouts?sync_mode=true"), p)
+	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.APIBase, "/v1/payments/payouts"), p)
 	if err != nil {
 		return &PayoutResponse{}, err
 	}
 
 	response := &PayoutResponse{}
-
 	err = c.SendWithAuth(req, response)
 	if err != nil {
 		return response, err

--- a/types.go
+++ b/types.go
@@ -167,14 +167,26 @@ type (
 		Value    string `json:"value,omitempty"`
 	}
 
-	// ErrorResponse https://developer.paypal.com/docs/api/errors/
+	// Error https://developer.paypal.com/docs/api/errors/
+	ErrorFields struct {
+		Name            string   `json:"name"`
+		DebugID         string   `json:"debug_id"`
+		Message         string   `json:"message"`
+		InformationLink string   `json:"information_link"`
+		Details         []Detail `json:"details"`
+	}
+
+	// ErrorResponse includes the http response and error
 	ErrorResponse struct {
-		Response        *http.Response `json:"-"`
-		Name            string         `json:"name"`
-		DebugID         string         `json:"debug_id"`
-		Message         string         `json:"message"`
-		InformationLink string         `json:"information_link"`
-		Details         string         `json:"details"`
+		Response *http.Response `json:"-"`
+		ErrorFields
+	}
+
+	// Detail https://developer.paypal.com/docs/api/errors/#error-responses
+	Detail struct {
+		Field string
+		Issue string
+		Link  []Link
 	}
 
 	// ExecuteResponse struct
@@ -299,6 +311,7 @@ type (
 		BatchHeader *BatchHeader         `json:"batch_header"`
 		Items       []PayoutItemResponse `json:"items"`
 		Links       []Link               `json:"links"`
+		ErrorFields
 	}
 
 	// RedirectURLs struct


### PR DESCRIPTION
See the issue I filed in the original repo: https://github.com/logpacker/PayPal-Go-SDK/issues/31

Additionally, I changed the Send function to scan the error response into the payoutResponse struct instead of returning an error with a stripped-down string version of the error response